### PR TITLE
Rollback Redis client because of known problems

### DIFF
--- a/src/CoiniumServ/packages.config
+++ b/src/CoiniumServ/packages.config
@@ -24,5 +24,5 @@
   <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net47" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net47" />
   <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net47" />
-  <package id="StackExchange.Redis" version="1.2.6" targetFramework="net462" />
+  <package id="StackExchange.Redis" version="1.2.4" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Rollback Redis client because of known problems with StackExchange.Redis versions 1.2.5 and 1.2.4 against newest Redis 4.0.X database. Was unable to connect to Redis 4.0.6 on Ubuntu Server 16.04 until rolling back to version 1.2.4.